### PR TITLE
build: honor SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,12 +11,24 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Capture build datetime (UTC, ISO 8601) using chrono
-    let build_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    // Capture build datetime (UTC, ISO 8601) using chrono.
+    // Honor SOURCE_DATE_EPOCH (https://reproducible-builds.org/specs/source-date-epoch/)
+    // when set so builds are reproducible; fall back to the wall clock otherwise.
+    let build_time = match std::env::var("SOURCE_DATE_EPOCH") {
+        Ok(epoch) => epoch
+            .parse::<i64>()
+            .ok()
+            .and_then(|secs| chrono::DateTime::from_timestamp(secs, 0))
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+        Err(_) => chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+    };
 
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
     println!("cargo:rustc-env=BUILD_TIME={build_time}");
 
+    // Re-run when the reproducible-build timestamp changes.
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     // Re-run when HEAD changes
     println!("cargo:rerun-if-changed=.git/HEAD");
     if let Ok(head) = std::fs::read_to_string(".git/HEAD")


### PR DESCRIPTION
flycomp's `build.rs` bakes `chrono::Utc::now()` into the binary via `BUILD_TIME`, which makes any downstream build (e.g. flyline, and flycomp itself) non-reproducible — the embedded `Generated by flycomp … built <timestamp>` string differs on every build.

This honors [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) when set (falling back to the wall clock otherwise), which is the standard mechanism build tools and distros use to pin build timestamps. It's the same fix applied to flyline's own `build.rs`.

Verified downstream: with this change, `nix build --rebuild` of flyline is byte-identical on aarch64-darwin.